### PR TITLE
Fix incompatibilities with jupyter console

### DIFF
--- a/matplotlib_iterm2/backend_iterm2.py
+++ b/matplotlib_iterm2/backend_iterm2.py
@@ -5,6 +5,8 @@ for displaying images in the terminal: http://iterm2.com/images.html#/section/ho
 
 __author__ = 'Oleg Selivanov <oleg.a.selivanov@gmail.com>'
 
+import os
+import shutil
 import subprocess
 import tempfile
 
@@ -13,17 +15,36 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.figure import Figure
-from PIL import Image
+
+# Whether to close figures
+# TODO: Make this configurable
+CLOSE = True
 
 try:
     from IPython import get_ipython
 except ImportError:
     get_ipython = lambda: None
 
-# TODO(oleg): Show better message if PIL/Pillow is not installed.
-# TODO(oleg): Check if imgcat script exists.
-# TODO(lukelbd): Turn CLOSE into configurable setting.
-CLOSE = True
+try:
+    from PIL import Image
+except ImportError:
+    raise RuntimeError("Package 'pillow' is required for matplotlib_iterm2 backend.")
+
+if 'TERM_PROGRAM' in os.environ:
+    terminal = os.environ['TERM_PROGRAM']
+else:
+    terminal = 'unknown'
+
+if 'iTerm' not in terminal:
+    raise RuntimeError(
+        'Current terminal {!r} is not compatible with matplotlib_iterm2 backend. '
+        "Please use 'iTerm' instead: http://iterm.com".format(terminal)
+    )
+if not shutil.which('imgcat'):
+    raise RuntimeError(
+        "iTerm2 executable 'imgcat' not found in $PATH. For install "
+        'instructions see: https://iterm2.com/documentation-images.html'
+    )
 
 
 def _draw_output(output):

--- a/matplotlib_iterm2/backend_iterm2.py
+++ b/matplotlib_iterm2/backend_iterm2.py
@@ -93,7 +93,7 @@ def new_figure_manager(num, *args, **kwargs):
     # Generate instance of manager subclass
     cls = kwargs.pop('FigureClass', Figure)
     fig = cls(*args, **kwargs)
-    canvas = FigureCanvasAgg(fig)
+    canvas = FigureCanvas(fig)
     return FigureManagerInline(canvas, num)
 
 
@@ -105,6 +105,11 @@ def show():
     finally:
         if CLOSE:
             matplotlib.pyplot.close('all')
+
+
+class FigureCanvas(FigureCanvasAgg):
+    # Figure canvas required for pyplot backends in matplotlib > 3.6
+    required_interactive_framework = None
 
 
 class FigureManagerInline(FigureManagerBase):


### PR DESCRIPTION
Resolves #3. This makes `matplotlib_iterm2` work in both `ipython` and `jupyter console`.

Example with `ipython`:

<img width="657" alt="Screen Shot 2022-03-02 at 6 56 57 PM" src="https://user-images.githubusercontent.com/19657652/156481518-6f76cc40-83dd-4f1d-88f6-a6bff3ffd2f9.png">


Example with `jupyter console`:

<img width="714" alt="Screen Shot 2022-03-02 at 6 55 49 PM" src="https://user-images.githubusercontent.com/19657652/156481407-76469aac-4a5b-4eec-a7a0-04afb5f74d22.png">

